### PR TITLE
accept cache version for story requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import (
 )
 
 func main() {
-	storyblokClient := storyblok.NewClient("TOKEN")
+	storyblokClient := storyblok.NewClient(storyblok.ClientInput{Token: "TOKEN"})
 	ctx := context.Background()
 
 	input := &storyblok.StoryInput{

--- a/space.go
+++ b/space.go
@@ -1,0 +1,18 @@
+package storyblok
+
+type (
+	// Space is a struct representation of the space object
+	// https://www.storyblok.com/docs/api/content-delivery#core-resources/spaces/the-space-object
+	Space struct {
+		ID      int    `json:"id"`
+		Name    string `json:"name"`
+		Domain  string `json:"domain"`
+		Version int    `json:"version"`
+	}
+
+	// SpaceResponse represents the structured reponse from Storyblok
+	// for a single space
+	SpaceResponse struct {
+		Space Space `json:"space"`
+	}
+)

--- a/story.go
+++ b/story.go
@@ -25,7 +25,7 @@ type (
 		TranslatedSlugs  []*TranslatedSlug `json:"translated_slugs"`
 	}
 
-	// StoryResponse represents the structured reponse from Storyblok
+	// StoryResponse represents the structured response from Storyblok
 	// for a single story
 	// https://www.storyblok.com/docs/api/content-delivery#core-resources/stories/the-story-object
 	StoryResponse struct {

--- a/storyblok.go
+++ b/storyblok.go
@@ -16,13 +16,13 @@ type (
 	Client struct {
 		baseURL      string
 		token        string
-		SpaceVersion int
+		CacheVersion int
 		HTTPClient   HTTPClient
 	}
 
 	ClientInput struct {
-		UseLatestSpace bool
-		Token          string
+		CacheVersion int
+		Token        string
 	}
 )
 
@@ -31,15 +31,8 @@ func NewClient(input ClientInput) *Client {
 	client := &Client{
 		baseURL:    baseURLv1,
 		token:      input.Token,
+		CacheVersion: input.CacheVersion,
 		HTTPClient: DefaultHTTPClient(),
-	}
-
-	if input.UseLatestSpace {
-		// Get the latest space version and use it for all subsequent story calls
-		space, err := client.GetLatestSpace(context.Background())
-		if err == nil {
-			client.SpaceVersion = space.Version
-		}
 	}
 	return client
 }
@@ -89,10 +82,8 @@ func (c *Client) GetStory(ctx context.Context,
 
 	q := req.URL.Query()
 	q.Add("token", c.token)
-	// always add the current datetime as a param to prevent getting cached content
-	//q.Add("refresher", strconv.Itoa(int(time.Now().Unix())))
-	if c.SpaceVersion != 0 {
-		q.Add("cv", strconv.Itoa(c.SpaceVersion))
+	if c.CacheVersion != 0 {
+		q.Add("cv", strconv.Itoa(c.CacheVersion))
 	}
 	req.URL.RawQuery = q.Encode()
 

--- a/storyblok.go
+++ b/storyblok.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 )
 
 const baseURLv1 = "https://api.storyblok.com/v1/cdn"
@@ -89,6 +90,7 @@ func (c *Client) GetStory(ctx context.Context,
 
 	q := req.URL.Query()
 	q.Add("token", c.token)
+	q.Add("dt", strconv.Itoa(int(time.Now().Unix())))
 	if c.SpaceVersion != 0 {
 		q.Add("cv", strconv.Itoa(c.SpaceVersion))
 	}

--- a/storyblok.go
+++ b/storyblok.go
@@ -28,13 +28,12 @@ type (
 
 // NewClient returns a pointer to Client
 func NewClient(input ClientInput) *Client {
-	client := &Client{
+	return &Client{
 		baseURL:    baseURLv1,
 		token:      input.Token,
 		CacheVersion: input.CacheVersion,
 		HTTPClient: DefaultHTTPClient(),
 	}
-	return client
 }
 
 // GetLatestSpace gets the latest space version so that we can always deliver the latest content

--- a/storyblok.go
+++ b/storyblok.go
@@ -54,7 +54,6 @@ func (c *Client) GetLatestSpace(ctx context.Context) (*Space, *ResponseError) {
 	return &res.Space, nil
 }
 
-
 // GetStory returns a story object for the full_slug, id or uuid if
 // authenticated using a preview or public token.
 //

--- a/storyblok.go
+++ b/storyblok.go
@@ -20,7 +20,6 @@ type Client struct {
 
 // NewClient returns a pointer to Client
 func NewClient(token string) *Client {
-	// get the latest cache version
 	client := &Client{
 		baseURL:      baseURLv1,
 		token:        token,

--- a/storyblok.go
+++ b/storyblok.go
@@ -12,19 +12,49 @@ const baseURLv1 = "https://api.storyblok.com/v1/cdn"
 
 // Client is the client struct used to access the Storyblok APIs
 type Client struct {
-	baseURL    string
-	token      string
-	HTTPClient HTTPClient
+	baseURL      string
+	token        string
+	SpaceVersion int
+	HTTPClient   HTTPClient
 }
 
 // NewClient returns a pointer to Client
 func NewClient(token string) *Client {
-	return &Client{
-		baseURL:    baseURLv1,
-		token:      token,
-		HTTPClient: DefaultHTTPClient(),
+	// get the latest cache version
+	client := &Client{
+		baseURL:      baseURLv1,
+		token:        token,
+		HTTPClient:   DefaultHTTPClient(),
 	}
+	// Get the latest space version for all subsequent story calls
+    space, err := client.GetLatestSpace(context.Background())
+    if err == nil {
+		client.SpaceVersion = space.Version
+	}
+	return client
 }
+
+// GetLatestSpace gets the latest space version so that we can always deliver the latest content
+//
+// https://www.storyblok.com/docs/api/content-delivery#topics/cache-invalidation
+func (c *Client) GetLatestSpace(ctx context.Context) (*Space, *ResponseError) {
+	endpoint := fmt.Sprintf("%s/spaces/me", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, NewResponseError(http.StatusInternalServerError, errCodeRequestSetupFailed)
+	}
+
+	q := req.URL.Query()
+	q.Add("token", c.token)
+	req.URL.RawQuery = q.Encode()
+
+	res := SpaceResponse{}
+	if err := c.sendRequest(req, &res); err != nil {
+		return nil, err
+	}
+	return &res.Space, nil
+}
+
 
 // GetStory returns a story object for the full_slug, id or uuid if
 // authenticated using a preview or public token.
@@ -50,6 +80,9 @@ func (c *Client) GetStory(ctx context.Context,
 
 	q := req.URL.Query()
 	q.Add("token", c.token)
+	if c.SpaceVersion != 0 {
+		q.Add("cv", string(c.SpaceVersion))
+	}
 	req.URL.RawQuery = q.Encode()
 
 	res := StoryResponse{}
@@ -79,7 +112,8 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) *ResponseError {
 	}
 
 	if err = json.NewDecoder(res.Body).Decode(&v); err != nil {
-		return NewResponseError(http.StatusInternalServerError, errCodeRequestDecodeFailed)
+		return NewResponseError(http.StatusInternalServerError,
+			fmt.Sprintf("%s: %s", errCodeRequestDecodeFailed, err.Error()))
 	}
 
 	return nil

--- a/storyblok.go
+++ b/storyblok.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 )
 
 const baseURLv1 = "https://api.storyblok.com/v1/cdn"
@@ -91,7 +90,7 @@ func (c *Client) GetStory(ctx context.Context,
 	q := req.URL.Query()
 	q.Add("token", c.token)
 	// always add the current datetime as a param to prevent getting cached content
-	q.Add("refresher", strconv.Itoa(int(time.Now().Unix())))
+	//q.Add("refresher", strconv.Itoa(int(time.Now().Unix())))
 	if c.SpaceVersion != 0 {
 		q.Add("cv", strconv.Itoa(c.SpaceVersion))
 	}

--- a/storyblok.go
+++ b/storyblok.go
@@ -90,7 +90,8 @@ func (c *Client) GetStory(ctx context.Context,
 
 	q := req.URL.Query()
 	q.Add("token", c.token)
-	q.Add("dt", strconv.Itoa(int(time.Now().Unix())))
+	// always add the current datetime as a param to prevent getting cached content
+	q.Add("refresher", strconv.Itoa(int(time.Now().Unix())))
 	if c.SpaceVersion != 0 {
 		q.Add("cv", strconv.Itoa(c.SpaceVersion))
 	}

--- a/storyblok.go
+++ b/storyblok.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 const baseURLv1 = "https://api.storyblok.com/v1/cdn"
@@ -25,6 +26,7 @@ func NewClient(token string) *Client {
 		token:        token,
 		HTTPClient:   DefaultHTTPClient(),
 	}
+
 	// Get the latest space version for all subsequent story calls
     space, err := client.GetLatestSpace(context.Background())
     if err == nil {
@@ -79,7 +81,7 @@ func (c *Client) GetStory(ctx context.Context,
 	q := req.URL.Query()
 	q.Add("token", c.token)
 	if c.SpaceVersion != 0 {
-		q.Add("cv", string(c.SpaceVersion))
+		q.Add("cv", strconv.Itoa(c.SpaceVersion))
 	}
 	req.URL.RawQuery = q.Encode()
 

--- a/storyblok_test.go
+++ b/storyblok_test.go
@@ -19,7 +19,7 @@ var (
 
 func init() {
 	ctx = context.Background()
-	storyblockClient = storyblok.NewClient("access_token")
+	storyblockClient = storyblok.NewClient(storyblok.ClientInput{Token: "access_token"})
 	storyblockClient.HTTPClient = &mocks.MockHTTPClient{}
 }
 


### PR DESCRIPTION
This was blocking me since the returned content was always cached.

Changes:
- Add new CacheVersion attribute to the Client
- Add new Input for the Client creation
- Add function to get latest space version
 
Additional info:
https://www.storyblok.com/docs/api/content-delivery#topics/cache-invalidation


